### PR TITLE
Support credentials via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Note that when name is specified in 'find' then search can be further defined st
 Example
 -------
 
-Login with your username and password:
+Login with your username and password or via environment variables `ISL_USER` and `ISL_PASSWORD`:
 
-	>>> from islendingabok import IslendingabokAPI
-        >>> api = IslendingabokAPI(username, password)
+        >>> from islendingabok import IslendingabokAPI
+        >>> api = IslendingabokAPI()  # or IslendingabokAPI(username, password)
         >>> user_info = api.me()
         >>> print(user_info['name'])
 	Ólafur Ragnar Grímsson

--- a/islendingabok.py
+++ b/islendingabok.py
@@ -2,6 +2,7 @@
 # encoding: utf-8
 
 from urllib.parse import urlencode
+import os
 import requests
 
 
@@ -16,9 +17,14 @@ class ClientError(Exception):
 class IslendingabokAPI(object):
     API_PATH = "http://www.islendingabok.is/ib_app/"
 
-    def __init__(self, username, password):
-        self.username = username
-        self.password = password
+    def __init__(self, username=None, password=None):
+        self.username = username or os.getenv("ISL_USER")
+        self.password = password or os.getenv("ISL_PASSWORD")
+
+        if not self.username or not self.password:
+            raise ClientError(
+                "Missing credentials. Provide username and password as arguments or via ISL_USER and ISL_PASSWORD environment variables."
+            )
         
         self.session = requests.Session()
         self.session_id = None

--- a/test_islbok.py
+++ b/test_islbok.py
@@ -3,6 +3,7 @@
 
 from islendingabok import IslendingabokAPI
 import argparse
+import os
 
 
 def main(username, password):
@@ -28,10 +29,10 @@ def main(username, password):
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description='Connects to Islendingabok and accesses user data.')
-    parser.add_argument('username',
-        help='username on Islendingabok')
-    parser.add_argument('password',
-        help='password on Islendingabok')
+    parser.add_argument('--username', default=os.getenv('ISL_USER'),
+        help='username on Islendingabok (defaults to ISL_USER env variable)')
+    parser.add_argument('--password', default=os.getenv('ISL_PASSWORD'),
+        help='password on Islendingabok (defaults to ISL_PASSWORD env variable)')
 
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary
- load `ISL_USER` and `ISL_PASSWORD` when username and password are not provided
- allow the helper script to pull credentials from environment variables
- update README example

## Testing
- `python3 -m py_compile islendingabok.py test_islbok.py`

------
https://chatgpt.com/codex/tasks/task_e_6857f73870ec832e8e8ad1e1c6607fca